### PR TITLE
feat: 設定を外部ファイルに分離し、ドキュメントを追加

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,88 @@
+# 設定ファイルガイド
+
+このアプリケーションでは、地図のデータや表示、経路探索の挙動をJSONファイルでカスタマイズできます。設定ファイルは `data/` ディレクトリにあります。
+
+## 1. アプリケーション設定 (`data/config.json`)
+
+アプリケーションの全体的な動作を制御します。
+
+```json
+{
+    "pathfinding": {
+        "avoidRoadTypes": ["mountain"],
+        "kShortestPaths": 3
+    },
+    "rendering": {
+        "routeColors": ["#ffd700", "#00bfff", "#32cd32"],
+        "nodeColors": {
+            "start": "green",
+            "end": "red",
+            "via": "orange",
+            "default": "lightblue"
+        }
+    }
+}
+```
+
+### `pathfinding`
+- `avoidRoadTypes`: 経路探索時に避ける道路の種別を文字列の配列で指定します。`data/roadTypes.json` のキーと一致させます。
+- `kShortestPaths`: 経由地がない場合に、探索する代替経路の最大数を整数で指定します。
+
+### `rendering`
+- `routeColors`: 地図上に表示される経路の色を、カラーコードの配列で指定します。複数の経路が表示される場合に、この配列の色が順番に使われます。
+- `nodeColors`: ノード（地点）の種類ごとの色をオブジェクトで指定します。
+    - `start`: 出発地
+    - `end`: 到着地
+    - `via`: 経由地
+    - `default`: その他のノード
+
+---
+
+## 2. 道路種別のスタイル設定 (`data/roadTypes.json`)
+
+道路の種類ごとの見た目を定義します。
+
+```json
+{
+    "default": { "color": "black", "lineWidth": 1, "style": "solid" },
+    "highway": { "color": "red", "lineWidth": 3, "style": "solid" },
+    "prefectural": { "color": "blue", "lineWidth": 2, "style": "solid" },
+    "city": { "color": "green", "lineWidth": 1.5, "style": "solid" },
+    "mountain": { "color": "brown", "lineWidth": 1, "style": "dashed" },
+    "river": { "color": "cyan", "lineWidth": 1, "style": "dotted" }
+}
+```
+
+- **キー**: 道路の種別名（`data/edges.json` で使用）
+- **値 (オブジェクト)**:
+    - `color`: 道路の色をカラーコードまたは色名で指定します。
+    - `lineWidth`: 道路の線の太さを数値で指定します。
+    - `style`: 線のスタイルを `"solid"` (実線), `"dashed"` (破線), `"dotted"` (点線) から選びます。
+
+---
+
+## 3. 地図データ
+
+### ノード（地点）データ (`data/nodes.json`)
+
+地図上の表示されるノード（地点）とその座標を定義します。
+
+- **形式**: `{"ノード名": [x座標, y座標]}` のオブジェクト
+- **例**: `{"村山駅": [500, 300], "楯岡": [450, 350]}`
+
+### 非表示ノードデータ (`data/hiddenNodes.json`)
+
+経路計算には使われるが、地図上には表示されないノードを定義します。主に、道路の形状を滑らかにするための中間点として使用します。
+
+- **形式**: `nodes.json` と同じ
+- **例**: `{"交差点A": [510, 320]}`
+
+### エッジ（道路）データ (`data/edges.json`)
+
+ノード間をつなぐエッジ（道路）を定義します。
+
+- **形式**: `["始点ノード", "終点ノード", コスト, "道路種別"]` の配列
+- **例**: `["楯岡", "東沢", 4, "city"]`
+    - `始点ノード`, `終点ノード`: `nodes.json` または `hiddenNodes.json` で定義したノード名
+    - `コスト`: 経路計算に使われる距離や時間などの重み（数値）
+    - `道路種別`: `roadTypes.json` で定義したキー（文字列）

--- a/data/config.json
+++ b/data/config.json
@@ -1,0 +1,15 @@
+{
+    "pathfinding": {
+        "avoidRoadTypes": ["mountain"],
+        "kShortestPaths": 3
+    },
+    "rendering": {
+        "routeColors": ["#ffd700", "#00bfff", "#32cd32"],
+        "nodeColors": {
+            "start": "green",
+            "end": "red",
+            "via": "orange",
+            "default": "lightblue"
+        }
+    }
+}

--- a/data/roadTypes.json
+++ b/data/roadTypes.json
@@ -1,0 +1,8 @@
+{
+    "default": { "color": "black", "lineWidth": 1, "style": "solid" },
+    "highway": { "color": "red", "lineWidth": 3, "style": "solid" },
+    "prefectural": { "color": "blue", "lineWidth": 2, "style": "solid" },
+    "city": { "color": "green", "lineWidth": 1.5, "style": "solid" },
+    "mountain": { "color": "brown", "lineWidth": 1, "style": "dashed" },
+    "river": { "color": "cyan", "lineWidth": 1, "style": "dotted" }
+}

--- a/js/modules/map-renderer.js
+++ b/js/modules/map-renderer.js
@@ -1,5 +1,5 @@
 // Canvasへの描画を担当するモジュール
-import { getState, roadTypes, isHiddenNode } from './state.js';
+import { getState, isHiddenNode } from './state.js';
 
 let ctx;
 let canvas;
@@ -32,7 +32,8 @@ function restoreViewTransform() {
 }
 
 function getRouteDisplayColor(routeIndex) {
-    const colors = ["#ffd700", "#00bfff", "#32cd32"]; // yellow, cyan, lime
+    const { config } = getState();
+    const colors = config.rendering?.routeColors || ["#ffd700", "#00bfff", "#32cd32"];
     return colors[routeIndex % colors.length];
 }
 
@@ -51,7 +52,7 @@ export function drawMap() {
     const {
         nodes, allNodes, edges, viewState, start, end, viaNodes,
         shortestPath, allRouteResults, showingAllPaths,
-        selectedRouteIndex, selectedPathIndex
+        selectedRouteIndex, selectedPathIndex, roadTypes, config
     } = state;
     const { scale } = viewState;
 
@@ -61,14 +62,12 @@ export function drawMap() {
     ctx.clearRect(0, 0, canvasWidth, canvasHeight);
     applyViewTransform();
 
-    const roadSettings = {
-        avoidMountain: document.getElementById("avoidMountain")?.checked ?? true
-    };
+    const avoidRoadTypes = config.pathfinding?.avoidRoadTypes || [];
 
     // Draw edges
     edges.forEach((edge) => {
         const [a, b, d, roadType = "default"] = edge;
-        let isRoadDisabled = roadSettings.avoidMountain && roadType === "mountain";
+        let isRoadDisabled = avoidRoadTypes.includes(roadType);
 
         const [x1, y1] = allNodes[a] || [0, 0];
         const [x2, y2] = allNodes[b] || [0, 0];
@@ -176,9 +175,10 @@ export function drawMap() {
         ctx.strokeStyle = isInAnyPath ? "orange" : "black";
         ctx.lineWidth = (isInAnyPath ? 3 : 1) / scale;
 
-        ctx.fillStyle = (name === start) ? "green" :
-                       (name === end) ? "red" :
-                       (viaNodes.includes(name) ? "orange" : "lightblue");
+        const nodeColors = config.rendering?.nodeColors || { start: "green", end: "red", via: "orange", default: "lightblue" };
+        ctx.fillStyle = (name === start) ? nodeColors.start :
+                       (name === end) ? nodeColors.end :
+                       (viaNodes.includes(name) ? nodeColors.via : nodeColors.default);
         ctx.fill();
         ctx.stroke();
 

--- a/js/modules/pathfinding.js
+++ b/js/modules/pathfinding.js
@@ -1,4 +1,5 @@
 // 経路探索アルゴリズムを担当するモジュール
+import { getState } from './state.js';
 
 /**
  * 道路設定に基づいてフィルターされたグラフを構築する
@@ -6,13 +7,15 @@
  * @param {Object} roadSettings - 道路設定 (e.g., { avoidMountain: true })
  * @returns {Object} フィルターされたグラフ
  */
-export function buildFilteredGraph(edges, roadSettings) {
+export function buildFilteredGraph(edges) {
+    const { config } = getState();
+    const avoidRoadTypes = config.pathfinding?.avoidRoadTypes || [];
     const filteredGraph = {};
 
     for (let edge of edges) {
         const [a, b, d, roadType = "default"] = edge;
 
-        if (roadSettings.avoidMountain && roadType === "mountain") {
+        if (avoidRoadTypes.includes(roadType)) {
             continue;
         }
 
@@ -206,10 +209,13 @@ function findAllShortestPaths(points, graph) {
  * @param {number} maxRoutes - 見つける候補の最大数
  * @returns {Array<{distance: number, paths: Array<Array<string>>}>}
  */
-export function findTopRoutes(points, graph, maxRoutes = 3) {
+export function findTopRoutes(points, graph) {
+    const { config } = getState();
+    const k = config.pathfinding?.kShortestPaths || 3;
+
     if (points.length === 2) {
         // 経由地がない場合はYen's algorithmで複数候補を探す
-        return findTopKPaths(points[0], points[1], graph, maxRoutes)
+        return findTopKPaths(points[0], points[1], graph, k)
             .map(r => ({ distance: r.distance, paths: [r.path] }));
     }
     // 経由地がある場合は、最短距離の組み合わせのみを探す

--- a/js/modules/state.js
+++ b/js/modules/state.js
@@ -1,14 +1,5 @@
 // アプリケーションの状態を管理するモジュール
 
-export const roadTypes = {
-    "default": { color: "black", lineWidth: 1, style: "solid" },
-    "highway": { color: "red", lineWidth: 3, style: "solid" },
-    "prefectural": { color: "blue", lineWidth: 2, style: "solid" },
-    "city": { color: "green", lineWidth: 1.5, style: "solid" },
-    "mountain": { color: "brown", lineWidth: 1, style: "dashed" },
-    "river": { color: "cyan", lineWidth: 1, style: "dotted" }
-};
-
 export const MAX_VIA = 5;
 
 const state = {
@@ -17,6 +8,8 @@ const state = {
     edges: [],
     allNodes: {},
     graph: {},
+    config: {},
+    roadTypes: {},
 
     viewState: {
         scale: 1.0,
@@ -46,6 +39,14 @@ export function setData({ nodes, hiddenNodes, edges, allNodes }) {
     state.hiddenNodes = hiddenNodes;
     state.edges = edges;
     state.allNodes = allNodes;
+}
+
+export function setConfig(newConfig) {
+    state.config = newConfig;
+}
+
+export function setRoadTypes(newRoadTypes) {
+    state.roadTypes = newRoadTypes;
 }
 
 export function setGraph(graph) {

--- a/js/script.js
+++ b/js/script.js
@@ -3,7 +3,7 @@
 // ==================================================================================
 import {
     getState, setData, setGraph, clearSelection, resetView as resetViewFromState,
-    setSelectedRoute, toggleShowAllPaths, setPathResults
+    setSelectedRoute, toggleShowAllPaths, setPathResults, setConfig, setRoadTypes
 } from './modules/state.js';
 import { initializeMap, drawMap } from './modules/map-renderer.js';
 import { buildFilteredGraph, findTopRoutes } from './modules/pathfinding.js';
@@ -49,8 +49,8 @@ function getRoadSettings() {
  */
 function updateGraph() {
     const { edges } = getState();
-    const roadSettings = getRoadSettings();
-    const filteredGraph = buildFilteredGraph(edges, roadSettings);
+    // todo: avoidMountainチェックボックスの処理を汎用化する
+    const filteredGraph = buildFilteredGraph(edges);
     setGraph(filteredGraph);
 }
 
@@ -71,7 +71,7 @@ export function calculatePath() {
         return;
     }
 
-    const routeResults = findTopRoutes(points, state.graph, 3);
+    const routeResults = findTopRoutes(points, state.graph);
     if (routeResults.length === 0) {
         alert("経路が見つかりませんでした。設定を変更してみてください。");
         setPathResults({ shortestPath: [], allRouteResults: [] });
@@ -132,15 +132,23 @@ export function showAllPaths() {
  */
 async function loadData() {
     try {
-        const [nodesRes, hiddenNodesRes, edgesRes] = await Promise.all([
+        const [nodesRes, hiddenNodesRes, edgesRes, configRes, roadTypesRes] = await Promise.all([
             fetch('data/nodes.json'),
             fetch('data/hiddenNodes.json'),
-            fetch('data/edges.json')
+            fetch('data/edges.json'),
+            fetch('data/config.json'),
+            fetch('data/roadTypes.json')
         ]);
         const nodes = await nodesRes.json();
         const hiddenNodes = await hiddenNodesRes.json();
         const edges = await edgesRes.json();
+        const config = await configRes.json();
+        const roadTypes = await roadTypesRes.json();
+
         setData({ nodes, hiddenNodes, edges, allNodes: { ...nodes, ...hiddenNodes } });
+        setConfig(config);
+        setRoadTypes(roadTypes);
+
     } catch (error) {
         console.error("データの読み込みに失敗しました:", error);
         document.getElementById('container').innerHTML = '<h1>エラー</h1><p>地図データの読み込みに失敗しました。ページを再読み込みしてください。</p>';


### PR DESCRIPTION
アプリケーションの柔軟性と保守性を向上させるため、これまでハードコードされていた設定値を外部のJSONファイルに分離しました。

主な変更点:
- `roadTypes`（道路の描画スタイル）を `data/roadTypes.json` に分離。
- 経路探索のオプション（回避する道路種別、探索する経路数）と描画オプション（経路やノードの色）を `data/config.json` として新規に作成。
- アプリケーション起動時にこれらの設定ファイルを読み込むように `script.js` と `state.js` を変更。
- `map-renderer.js` と `pathfinding.js` が、ハードコードされた値の代わりに読み込んだ設定値を使用するように修正。
- 追加された設定ファイルと既存のデータファイルの役割を説明する `CONFIG.md` を作成。